### PR TITLE
fix(sort): handle CRLF CSV input

### DIFF
--- a/csv_surgeon/cli_sort.py
+++ b/csv_surgeon/cli_sort.py
@@ -1,17 +1,17 @@
 """CLI sub-command for sorting CSV files."""
 import argparse
 import csv
-import sys
 
-from csv_surgeon.reader import stream_rows
 from csv_surgeon.sort import sort_rows, sort_rows_multi
-from csv_surgeon.writer import write_rows
 
 
 def cmd_sort(args: argparse.Namespace) -> None:
     keys = args.key  # list of column names
     numeric_keys = args.numeric or []
-    rows = list(stream_rows(args.input, delimiter=args.delimiter))
+    with open(args.input, newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh, delimiter=args.delimiter)
+        fieldnames = list(reader.fieldnames or [])
+        rows = list(reader)
     if not rows:
         return
 
@@ -26,9 +26,11 @@ def cmd_sort(args: argparse.Namespace) -> None:
                             numeric_keys=numeric_keys)
         )
 
-    fieldnames = list(rows[0].keys())
     out = args.output or args.input
-    write_rows(out, sorted_rows, fieldnames=fieldnames, delimiter=args.delimiter)
+    with open(out, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames, delimiter=args.delimiter)
+        writer.writeheader()
+        writer.writerows(sorted_rows)
 
 
 def register_sort_parser(subparsers) -> None:

--- a/tests/test_cli_sort.py
+++ b/tests/test_cli_sort.py
@@ -59,3 +59,15 @@ def test_sort_multi_key(sample_csv):
     cmd_sort(NS(input=sample_csv, key=["city", "name"]))
     rows = _read(sample_csv)
     assert rows[0]["city"] == "Amsterdam"
+
+
+def test_sort_crlf_input_strips_carriage_returns(tmp_path):
+    data = tmp_path / "data.csv"
+    out = tmp_path / "sorted.csv"
+    data.write_bytes(b"name,age\r\njohn,30\r\nalice,25\r\n")
+
+    cmd_sort(NS(input=str(data), key=["age"], numeric=["age"], output=str(out)))
+
+    rows = _read(out)
+    assert [row["age"] for row in rows] == ["25", "30"]
+    assert all("\r" not in value for row in rows for value in row.values())


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Make the `sort` CLI read CSV rows with `csv.DictReader` opened using `newline=""`, so CRLF input is delegated to Python's CSV parser correctly.
- Write sorted output with `csv.DictWriter` opened using `newline=""`, preserving headers and avoiding embedded carriage returns.
- Add a regression test that sorts CRLF input and asserts no `\r` survives in field values.

## Related Issues / Closes
Closes #14

## Testing
- RED: `python3 -m pytest tests/test_cli_sort.py::test_sort_crlf_input_strips_carriage_returns -q` failed before the fix with `AttributeError: 'list' object has no attribute 'get'` in the sort path.
- `python3 -m pytest tests/test_cli_sort.py::test_sort_crlf_input_strips_carriage_returns -q` — passed.
- `python3 -m pytest tests/test_cli_sort.py -q` — passed.
- `python3 -m pytest tests/test_sort.py tests/test_reader.py tests/test_writer.py -q` — passed.
- `python3 -m compileall -q csv_surgeon/cli_sort.py` — passed.
- `git diff --check` — passed.

Also tried `python3 -m pytest -q`; it currently reports unrelated repository-wide failures outside this change (92 failed, 574 passed), including pre-existing list-vs-dict stream handling in other CLI modules and unrelated assertion mismatches. The sort-focused tests above pass after this fix.

## AI assistance disclosure
This draft PR was prepared by Hermes Agent as an automated maintainer-assist change. I verified the issue state, checked for duplicate PRs, made a minimal regression-tested fix, and opened it as a draft for maintainer review.
